### PR TITLE
Fixes, improvements, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ $ go build -overlay="$(go-patch-overlay getgid.patch)"
 
 This will work for patches aimed at the runtime or stdlib. It won't work for the compiler/linker.
 You can provide multiple patches. The patches will be applied in the order they're provided.
+The patches will applied to the sources in the GOROOT directory of the Go toolchain.
+This should be the same toolchain you'll use to build the program.
+The toolchain defaults to the current "go" command.
+Use the `-go` argument to point to a different toolchain.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 An experimental way to apply patches to the Go runtime at build time.
 
-Assuming you have a directory of [patches](./example/goroutineid/patches) to apply to the Go source tree, you can use it like this:
+Assuming you have a [patch](./example/goroutineid/patches/getgid.patch) to apply to the Go source tree, you can use it like this:
 
 ```
-$ go build -overlay="$(go-patch-overlay ./patches)"
+$ go build -overlay="$(go-patch-overlay getgid.patch)"
 ```
 
 This will work for patches aimed at the runtime or stdlib. It won't work for the compiler/linker.
+You can provide multiple patches. The patches will be applied in the order they're provided.

--- a/example/goroutineid/README.md
+++ b/example/goroutineid/README.md
@@ -5,5 +5,5 @@ An example for using the go-patch-overlay tool to hack a `runtime.Getid()` funct
 To run the code, you need to invoke `go` like this:
 
 ```
-$ go run -overlay="$(go-patch-overlay ./patches)"
+$ go run -overlay="$(go-patch-overlay ./patches/getgid.patch)"
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/felixge/go-patch-overlay
 
-go 1.16
+go 1.23.0
 
-require github.com/bluekeyes/go-gitdiff v0.5.1 // indirect
+require (
+	github.com/bluekeyes/go-gitdiff v0.5.1
+	golang.org/x/tools v0.34.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/bluekeyes/go-gitdiff v0.5.1 h1:nb0/nbk4SGxK80taUG+gKjOpUYhpkVxqDRULlMLsWng=
 github.com/bluekeyes/go-gitdiff v0.5.1/go.mod h1:QpfYYO1E0fTVHVZAZKiRjtSGY9823iCdvGXBcEzHGbM=
+golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
+golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=

--- a/main.go
+++ b/main.go
@@ -116,8 +116,14 @@ func (o Overlay) applyPatch(pathPath string, j *overlayJSON) error {
 		return err
 	}
 	for _, file := range files {
-		overlayPath := filepath.Join(o.OverlayDir, file.NewName)
 		srcPath := filepath.Join(o.Goroot, file.OldName)
+		if file.NewName == "" {
+			// Having an empty string as the replacement path in the
+			// overlay tells the compiler the file doesn't exist
+			j.Replace[srcPath] = ""
+			continue
+		}
+		overlayPath := filepath.Join(o.OverlayDir, file.NewName)
 		if err := os.MkdirAll(filepath.Dir(overlayPath), 0755); err != nil {
 			return fmt.Errorf("making overlay path: %w", err)
 		}

--- a/main.go
+++ b/main.go
@@ -119,26 +119,34 @@ func (o Overlay) applyPatch(pathPath string, j *overlayJSON) error {
 		overlayPath := filepath.Join(o.OverlayDir, file.NewName)
 		srcPath := filepath.Join(o.Goroot, file.OldName)
 		if err := os.MkdirAll(filepath.Dir(overlayPath), 0755); err != nil {
-			return err
+			return fmt.Errorf("making overlay path: %w", err)
 		}
-		if _, err := os.Stat(overlayPath); os.IsNotExist(err) {
+		if file.OldName == "" {
+			// This is a new file. We still want to give it a
+			// "source" path in the overlay so the compiler knows
+			// it's there
+			srcPath = filepath.Join(o.Goroot, file.NewName)
+		} else if _, err := os.Stat(overlayPath); os.IsNotExist(err) {
 			if err := copyFile(srcPath, overlayPath); err != nil {
-				return err
+				return fmt.Errorf("copying %s to %s: %s", srcPath, overlayPath, err)
 			}
 		} else if err != nil {
-			return err
+			return fmt.Errorf("stat %s: %s", overlayPath, err)
 		}
 
-		beforeData, err := ioutil.ReadFile(overlayPath)
-		if err != nil {
-			return err
+		var beforeData []byte
+		if file.OldName != "" {
+			beforeData, err = ioutil.ReadFile(overlayPath)
+			if err != nil {
+				return fmt.Errorf("reading %s: %s", overlayPath, err)
+			}
 		}
 		afterData := &bytes.Buffer{}
 		if err := gitdiff.NewApplier(bytes.NewReader(beforeData)).ApplyFile(afterData, file); err != nil {
 			return err
 		}
 		if err := ioutil.WriteFile(overlayPath, afterData.Bytes(), 0644); err != nil {
-			return err
+			return fmt.Errorf("writing %s: %s", overlayPath, err)
 		}
 		j.Replace[srcPath] = overlayPath
 	}

--- a/main.go
+++ b/main.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
-	"runtime"
+	"strings"
 
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
 )
@@ -22,8 +23,9 @@ func main() {
 
 func run() error {
 	overlayDir := flag.String("overlay", "", "Directory for overlay, defaults to a new temporary directory")
+	goPath := flag.String("go", "go", "Path to Go toolchain")
 	flag.Parse()
-	o := Overlay{Patches: flag.Args(), OverlayDir: *overlayDir}
+	o := Overlay{Patches: flag.Args(), OverlayDir: *overlayDir, GoPath: *goPath}
 	jsonPath, err := o.Generate()
 	if err != nil {
 		return err
@@ -35,6 +37,7 @@ func run() error {
 type Overlay struct {
 	Patches    []string
 	OverlayDir string
+	GoPath     string
 	Goroot     string
 }
 
@@ -56,6 +59,22 @@ func (o Overlay) Generate() (string, error) {
 	return jsonPath, err
 }
 
+func (o *Overlay) resolveGOROOT() error {
+	if o.Goroot != "" {
+		return nil
+	}
+	if o.GoPath == "" {
+		o.GoPath = "go"
+	}
+	cmd := exec.Command(o.GoPath, "env", "GOROOT")
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("resolving GOROOT: %w", err)
+	}
+	o.Goroot = strings.TrimSpace(string(b))
+	return nil
+}
+
 func (o *Overlay) generate(j *overlayJSON) error {
 	if o.OverlayDir == "" {
 		tmpDir, err := ioutil.TempDir("", "go-patch-overlay")
@@ -71,8 +90,8 @@ func (o *Overlay) generate(j *overlayJSON) error {
 		return err
 	}
 
-	if o.Goroot == "" {
-		o.Goroot = runtime.GOROOT()
+	if err := o.resolveGOROOT(); err != nil {
+		return err
 	}
 
 	if err := os.RemoveAll(o.OverlayDir); err != nil {

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
 
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
 )
@@ -22,8 +21,9 @@ func main() {
 }
 
 func run() error {
+	overlayDir := flag.String("overlay", "", "Directory for overlay, defaults to a new temporary directory")
 	flag.Parse()
-	o := Overlay{PatchDir: flag.Arg(0), OverlayDir: flag.Arg(1)}
+	o := Overlay{Patches: flag.Args(), OverlayDir: *overlayDir}
 	jsonPath, err := o.Generate()
 	if err != nil {
 		return err
@@ -33,7 +33,7 @@ func run() error {
 }
 
 type Overlay struct {
-	PatchDir   string
+	Patches    []string
 	OverlayDir string
 	Goroot     string
 }
@@ -78,13 +78,8 @@ func (o *Overlay) generate(j *overlayJSON) error {
 	if err := os.RemoveAll(o.OverlayDir); err != nil {
 		return err
 	}
-	patches, err := filepath.Glob(filepath.Join(o.PatchDir, "*.patch"))
-	if err != nil {
-		return err
-	}
-	sort.Strings(patches)
 
-	for _, patch := range patches {
+	for _, patch := range o.Patches {
 		if err := o.applyPatch(patch, j); err != nil {
 			return err
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/txtar"
+)
+
+func Test(t *testing.T) {
+	files, err := filepath.Glob("testdata/*.txtar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range files {
+		t.Run(filepath.Base(f), func(t *testing.T) { testPatches(t, f) })
+	}
+}
+
+func testPatches(t *testing.T, archive string) {
+	dir := t.TempDir()
+
+	var (
+		toolchain string
+		output    []byte
+		patches   []string
+		sources   []string
+	)
+
+	ar, err := txtar.ParseFile(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range ar.Files {
+		if f.Name == "toolchain" {
+			toolchain = strings.TrimSpace(string(f.Data))
+		}
+		if f.Name == "output.txt" {
+			output = f.Data
+		}
+		if strings.HasSuffix(f.Name, ".patch") {
+			patches = append(patches, filepath.Join(dir, f.Name))
+		}
+		if strings.HasSuffix(f.Name, ".go") {
+			sources = append(sources, filepath.Join(dir, f.Name))
+		}
+	}
+	if toolchain == "" {
+		t.Fatalf("%s did not specify a toolchain", archive)
+	}
+	if len(sources) == 0 {
+		t.Fatalf("no Go sources")
+	}
+	if len(patches) == 0 {
+		t.Fatalf("no patches")
+	}
+
+	fs, err := txtar.FS(ar)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.CopyFS(dir, fs); err != nil {
+		t.Fatal(err)
+	}
+
+	overlayDir := filepath.Join(dir, "overlay")
+	os.Mkdir(overlayDir, 0777)
+	o := Overlay{
+		OverlayDir: overlayDir,
+		GoPath:     toolchain,
+		Patches:    patches,
+	}
+
+	overlay, err := o.Generate()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	binary := filepath.Join(dir, "testprog")
+	cmd := exec.Command(toolchain,
+		"build",
+		"-overlay", overlay,
+		"-o", binary,
+	)
+	cmd.Args = append(cmd.Args, sources...)
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("building test program: %s, output:\n%s", err, b)
+	}
+
+	cmd = exec.Command(binary)
+	b, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("building test program: %s, output:\n%s", err, b)
+	}
+	if !bytes.Equal(output, b) {
+		t.Fatalf("wanted output:\n%s\ngot output: %s", output, b)
+	}
+}

--- a/testdata/add-delete-one-patch.txtar
+++ b/testdata/add-delete-one-patch.txtar
@@ -1,0 +1,42 @@
+This tests a sequence of patches which add and then delete a file.
+-- toolchain --
+go1.24.4
+-- add-delete.patch --
+diff --git a/src/weak/doc.go b/src/weak/doc.go
+deleted file mode 100644
+index 1af8e4c69b..0000000000
+--- a/src/weak/doc.go
++++ /dev/null
+@@ -1,9 +0,0 @@
+-// Copyright 2024 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-/*
+-Package weak provides ways to safely reference memory weakly,
+-that is, without preventing its reclamation.
+-*/
+-package weak
+diff --git a/src/weak/doc_new.go b/src/weak/doc_new.go
+new file mode 100644
+index 0000000000..d40b8c10db
+--- /dev/null
++++ b/src/weak/doc_new.go
+@@ -0,0 +1,4 @@
++// Test
++package weak
++
++func Test() string { return "hello world" }
+-- simple.go --
+package main
+
+import (
+	"fmt"
+	"weak"
+)
+
+func main() {
+	fmt.Println(weak.Test())
+}
+-- output.txt --
+hello world

--- a/testdata/add-delete.txtar
+++ b/testdata/add-delete.txtar
@@ -1,0 +1,34 @@
+This tests a patch that adds a file.
+-- toolchain --
+go1.24.4
+-- add.patch --
+diff --git a/src/math/rand/rand2.go b/src/math/rand/rand2.go
+new file mode 100644
+index 0000000000..e2d7bcf231
+--- /dev/null
++++ b/src/math/rand/rand2.go
+@@ -0,0 +1,3 @@
++package rand
++
++func NewFunction() int { return 0 }
+-- delete.patch --
+diff --git a/src/math/rand/rand2.go b/src/math/rand/rand2.go
+deleted file mode 100644
+index e2d7bcf231..0000000000
+--- a/src/math/rand/rand2.go
++++ /dev/null
+@@ -1,3 +0,0 @@
+-package rand
+-
+-func NewFunction() int { return 0 }
+-- simple.go --
+package main
+
+import (
+	"math/rand"
+)
+
+func main() {
+	// just check that this compiles
+	_ = rand.Int()
+}

--- a/testdata/add.txtar
+++ b/testdata/add.txtar
@@ -1,0 +1,26 @@
+This tests a patch that adds a file.
+-- toolchain --
+go1.24.4
+-- add.patch --
+diff --git a/src/math/rand/rand2.go b/src/math/rand/rand2.go
+new file mode 100644
+index 0000000000..e2d7bcf231
+--- /dev/null
++++ b/src/math/rand/rand2.go
+@@ -0,0 +1,3 @@
++package rand
++
++func NewFunction() int { return 0 }
+-- simple.go --
+package main
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+func main() {
+	fmt.Println(rand.NewFunction())
+}
+-- output.txt --
+0

--- a/testdata/move.txtar
+++ b/testdata/move.txtar
@@ -1,0 +1,30 @@
+This tests a patch which moves files
+-- toolchain --
+go1.24.4
+-- move.patch --
+diff --git a/src/math/rand/rand.go b/src/math/rand/rand.go
+index 4be1ca208a..faab8dd8a6 100644
+--- a/src/math/rand/rand.go
++++ b/src/math/rand/rand_moved.go
+@@ -446,7 +446,7 @@ func Uint64() uint64 { return globalRand().Uint64() }
+ func Int31() int32 { return globalRand().Int31() }
+ 
+ // Int returns a non-negative pseudo-random int from the default [Source].
+-func Int() int { return globalRand().Int() }
++func Int() int { return 42 }
+ 
+ // Int63n returns, as an int64, a non-negative pseudo-random number in the half-open interval [0,n)
+ // from the default [Source].
+-- simple.go --
+package main
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+func main() {
+	fmt.Println(rand.Int())
+}
+-- output.txt --
+42

--- a/testdata/sequence.txtar
+++ b/testdata/sequence.txtar
@@ -1,0 +1,45 @@
+This tests a sequence of two patches. The patches must be applied in order,
+since the first patch creates a function used by the second one.
+-- toolchain --
+go1.24.4
+-- part1.patch --
+diff --git a/src/math/rand/rand.go b/src/math/rand/rand.go
+index 4be1ca208a..a1cba7caf6 100644
+--- a/src/math/rand/rand.go
++++ b/src/math/rand/rand.go
+@@ -445,6 +445,8 @@ func Uint64() uint64 { return globalRand().Uint64() }
+ // from the default [Source].
+ func Int31() int32 { return globalRand().Int31() }
+ 
++func NewInt() int { return 42 }
++
+ // Int returns a non-negative pseudo-random int from the default [Source].
+ func Int() int { return globalRand().Int() }
+ 
+-- part2.patch --
+diff --git a/src/math/rand/rand.go b/src/math/rand/rand.go
+index a1cba7caf6..cbce0b6c3d 100644
+--- a/src/math/rand/rand.go
++++ b/src/math/rand/rand.go
+@@ -448,7 +448,7 @@ func Int31() int32 { return globalRand().Int31() }
+ func NewInt() int { return 42 }
+ 
+ // Int returns a non-negative pseudo-random int from the default [Source].
+-func Int() int { return globalRand().Int() }
++func Int() int { return NewInt() }
+ 
+ // Int63n returns, as an int64, a non-negative pseudo-random number in the half-open interval [0,n)
+ // from the default [Source].
+-- simple.go --
+package main
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+func main() {
+	fmt.Println(rand.Int())
+}
+-- output.txt --
+42

--- a/testdata/simple.txtar
+++ b/testdata/simple.txtar
@@ -1,0 +1,33 @@
+-- toolchain --
+go1.24.4
+-- simple.patch --
+diff --git a/src/math/rand/rand.go b/src/math/rand/rand.go
+index 4be1ca208a..faab8dd8a6 100644
+--- a/src/math/rand/rand.go
++++ b/src/math/rand/rand.go
+@@ -446,7 +446,7 @@ func Uint64() uint64 { return globalRand().Uint64() }
+ func Int31() int32 { return globalRand().Int31() }
+ 
+ // Int returns a non-negative pseudo-random int from the default [Source].
+-func Int() int { return globalRand().Int() }
++func Int() int { return 42 }
+ 
+ // Int63n returns, as an int64, a non-negative pseudo-random number in the half-open interval [0,n)
+ // from the default [Source].
+-- simple.go --
+package main
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+func main() {
+	fmt.Println(rand.Int())
+	fmt.Println(rand.Int())
+	fmt.Println(rand.Int())
+}
+-- output.txt --
+42
+42
+42


### PR DESCRIPTION
This PR brings a few fixes and improvements to the tool:

- Accept paths to patches rather than to a patch directory. This makes it easier to run (you don't need to make a separate directory to put your patches in). It also lets you supply them in a specific order, in case one depends on another.
- Accept a path to a Go toolchain. This makes it easier to test. It also makes the tool a little more flexible if a user built this tool with their default toolchain but wants to build the overlay/program with a different one (e.g. one of the `golang.org/dl/go1.x.y` ones)
- Make the tool work with patches that add new files or remove files.
- Add unit tests for all of this.

The changes are broken up into different commits in this PR. I would have stacked them but it doesn't seem like you can do that from a fork of a repo on GitHub?

There might still be patches this tool doesn't handle right, but I think with these changes we can now handle most of the ones we're likely to use.